### PR TITLE
Upgraded Rust compiler version

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,7 @@ endif
 CONTAINER_BUILD_ARGS += --build-arg FEDORA_IMAGE=registry.fedoraproject.org/fedora:38
 CONTAINER_BUILD_ARGS += --build-arg JAVASCRIPT_IMAGE=docker.io/library/node:20.3.0
 CONTAINER_BUILD_ARGS += --build-arg PYTHON_IMAGE=docker.io/library/python:3.11.4
-CONTAINER_BUILD_ARGS += --build-arg RUST_IMAGE=docker.io/library/rust:1.70
+CONTAINER_BUILD_ARGS += --build-arg RUST_IMAGE=docker.io/library/rust:1.71.1
 
 CONTAINER_IMAGE_LABELS += \
 	it.unige.project=MaCySTe \

--- a/src/containers/websocket_to_websocket/Containerfile
+++ b/src/containers/websocket_to_websocket/Containerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/rust:1.66
+FROM docker.io/library/rust:1.71.1
 
 COPY . /usr/src/websocket-to-websocket
 


### PR DESCRIPTION
I have updated the version for the Rust compiler so the issues with the websockets described in issue https://github.com/CRACK-MCR/MaCySTe/issues/2 can be resolved. 

Tested that the build and run of MaCySTE works on an Ubuntu 24.04.1 LTS Desktop, with ``make check`` reporting the following:
```
make -C src check
make[1]: Entering directory '/home/george/MaCySTe/src'
Found command cat
Found command envsubst
Found command flatpak-builder
Found command flatpak
Found command ip
Found command podman
Found command python3
Found command sysctl
Found command tee
Found command xdg-open
Podman version 4.9.3 is ok
Python version 3.12.3 (main, Nov  6 2024, 18:32:19) [GCC 13.2.0] is ok
make[1]: Leaving directory '/home/george/MaCySTe/src'
```